### PR TITLE
[FIX] Default Image

### DIFF
--- a/frontend/src/utils/ImageWithJWT.jsx
+++ b/frontend/src/utils/ImageWithJWT.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 function ImageWithJWT({ imageUrl }) {
   const [imageString, setImageString] = useState("");
   const token = localStorage.getItem("userToken");
+  const dummyImage = "https://dummyimage.com/600x400/eeeeee/eeeeee";
 
   useEffect(() => {
     const getBase64Image = async (res) => {
@@ -26,9 +27,14 @@ function ImageWithJWT({ imageUrl }) {
       .then(getBase64Image)
       .then((imgString) => setImageString(imgString))
       .catch((err) => console.error("Error fetching image:", err));
-  }, [imageUrl, token]);
+  }, [imageUrl]);
 
-  return <img src={imageString} alt="Loaded from JWT" />;
+  return (
+    <img
+      src={imageString.startsWith("data:text") ? dummyImage : imageString}
+      alt=""
+    />
+  );
 }
 ImageWithJWT.propTypes = {
   imageUrl: PropTypes.string.isRequired,


### PR DESCRIPTION
Dans ce commit:
Si l'imageUrl est null ou undefined, le fonctions ImageWithJWT va montrer le image default, qui est un image gris clair